### PR TITLE
feat: enable src directory

### DIFF
--- a/project.ts
+++ b/project.ts
@@ -76,7 +76,7 @@ export class Project {
         this.appRoot = path.resolve(appDir)
         this.mode = mode
         this.config = {
-            srcDir: '/',
+            srcDir: existsDirSync(path.join(this.appRoot, '/src/pages')) ? '/src' : '/',
             outputDir: '/dist',
             baseUrl: '/',
             defaultLocale: 'en',


### PR DESCRIPTION
## Issue

https://github.com/alephjs/aleph.js/issues/12

## Context

See https://nextjs.org/docs/advanced-features/src-directory

## Changes

- If a project contains `/src/pages` then change the `srcDir` to `/src`, otherwise default to `/`

## Considerations

- Need to add either tests or update one of/all of the examples
- Need to update documentation