### PR TITLE
Fix: Lack of URL encoding processing #31

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 Thumbs.db
 .aleph/
 dist/
+
+.vscode/launch.json

--- a/project.ts
+++ b/project.ts
@@ -221,7 +221,7 @@ export class Project {
     }
 
     async callAPI(req: ServerRequest, loc: { pathname: string, search?: string }): Promise<APIHandler | null> {
-        const [url] = this.#apiRouting.createRouter(loc)
+        const [url] = this.#apiRouting.createRouter({ ...loc, pathname: decodeURI(loc.pathname) })
         if (url.pagePath != '') {
             const moduleID = url.pagePath + '.js'
             if (this.#modules.has(moduleID)) {
@@ -1555,7 +1555,8 @@ function fixImportUrl(importUrl: string): string {
     if (isRemote) {
         return '/-/' + url.hostname + (url.port ? '/' + url.port : '') + pathname + ext
     }
-    return pathname + ext
+    const result = pathname + ext
+    return !isRemote && importUrl.startsWith('/api/') ? decodeURI(result) : result;
 }
 
 /** get hash(sha1) of the content, mix current aleph.js version when the second parameter is `true` */

--- a/routing.ts
+++ b/routing.ts
@@ -176,7 +176,8 @@ export class Routing {
 }
 
 export function getPagePath(moduleId: string): string {
-    return util.trimSuffix(moduleId, '.js').replace(reMDExt, '').toLowerCase().replace(/\s+/g, '-').replace(/^\/pages\//, '/').replace(/\/?index$/, '/')
+    const id = util.trimSuffix(moduleId, '.js').replace(reMDExt, '').toLowerCase().replace(/^\/pages\//, '/').replace(/\/?index$/, '/')
+    return id.startsWith('/api/') ? id : id.replace(/\s+/g, '-')
 }
 
 function matchPath(routePath: string, locPath: string): [Record<string, string>, boolean] {


### PR DESCRIPTION
- launch.json added to .gitignore to be able to attach my own projects for incremental debugging.
- Fixed #31, but only for public file paths.
    - added decodeURI().
    - moved the code block up to top of the serving order.
    - const lastModified = info.mtime?.toUTCString() ?? new Date().toUTCString()
    - Deno.lstat -> Deno.lstatSync, Deno.readFile -> Deno.readFileSync
