### PR TITLE
Implementing --host flag for production.

### DIFF
--- a/cli/dev.ts
+++ b/cli/dev.ts
@@ -21,5 +21,5 @@ export default async function (appDir: string, options: Record<string, string | 
         log.error(`invalid port '${options.port || options.p}'`)
         Deno.exit(1)
     }
-    start(appDir, port, true, Boolean(options.r || options.reload))
+    start(appDir, 'localhost', port, true, Boolean(options.r || options.reload))
 }

--- a/cli/start.ts
+++ b/cli/start.ts
@@ -8,7 +8,7 @@ Usage:
 if the <dir> is empty, the current directory will be used.
 
 Options:
-    --host           The address at which the server is to be started.
+    -hn, --hostname  The address at which the server is to be started.
     -p, --port       A port number to start the aleph.js app, default is 8080
     -L, --log-level  Set log level [possible values: debug, info]
     -r, --reload     Reload source code cache
@@ -17,7 +17,7 @@ Options:
 
 export default async function (appDir: string, options: Record<string, string | boolean>) {
     const { start } = await import('../server.ts')
-    const host = String(options.h || options.host || 'localhost')
+    const host = String(options.hn || options.hostname || 'localhost')
     const port = parseInt(String(options.p || options.port || '8080'))
     if (isNaN(port) || port <= 0 || !Number.isInteger(port)) {
         log.error(`invalid port '${options.port || options.p}'`)

--- a/cli/start.ts
+++ b/cli/start.ts
@@ -8,6 +8,7 @@ Usage:
 if the <dir> is empty, the current directory will be used.
 
 Options:
+    --host           The address at which the server is to be started.
     -p, --port       A port number to start the aleph.js app, default is 8080
     -L, --log-level  Set log level [possible values: debug, info]
     -r, --reload     Reload source code cache
@@ -16,10 +17,11 @@ Options:
 
 export default async function (appDir: string, options: Record<string, string | boolean>) {
     const { start } = await import('../server.ts')
+    const host = String(options.h || options.host || 'localhost')
     const port = parseInt(String(options.p || options.port || '8080'))
     if (isNaN(port) || port <= 0 || !Number.isInteger(port)) {
         log.error(`invalid port '${options.port || options.p}'`)
         Deno.exit(1)
     }
-    start(appDir, port, false, Boolean(options.r || options.reload))
+    start(appDir, host, port, false, Boolean(options.r || options.reload))
 }

--- a/server.ts
+++ b/server.ts
@@ -7,14 +7,14 @@ import { injectHmr, Project } from './project.ts'
 import { path, serve, ws } from './std.ts'
 import util, { hashShort } from './util.ts'
 
-export async function start(appDir: string, port: number, isDev = false, reload = false) {
+export async function start(appDir: string, hostname: string, port: number, isDev = false, reload = false) {
     const project = new Project(appDir, isDev ? 'development' : 'production', reload)
     await project.ready
 
     while (true) {
         try {
-            const s = serve({ port })
-            log.info(`Server ready on http://localhost:${port}`)
+            const s = serve({ hostname, port })
+            log.info(`Server ready on http://${hostname}:${port}`)
             for await (const req of s) {
                 const url = new URL('http://localhost/' + req.url)
                 const pathname = util.cleanPath(url.pathname)


### PR DESCRIPTION
This allows the user to change the hostname in production mode -
```
Start the app in production mode

Usage:
    aleph start <dir> [...options]

<dir> represents the directory of the aleph.js app,
if the <dir> is empty, the current directory will be used.

Options:
    --host           The address at which the server is to be started.
    -p, --port       A port number to start the aleph.js app, default is 8080
    -L, --log-level  Set log level [possible values: debug, info]
    -r, --reload     Reload source code cache
    -h, --help       Prints help message
```

Usage - 
`aleph start --host <hostname> <project>`