### PR TITLE
Rename version to VERSION

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -5,7 +5,7 @@ import log from './log.ts'
 import { getContentType } from './mime.ts'
 import { listenAndServe, path, ServerRequest, walk } from './std.ts'
 import util from './util.ts'
-import { version } from './version.ts'
+import { VERSION } from './version.ts'
 
 const commands = {
     'init': 'Create a new application',
@@ -15,7 +15,7 @@ const commands = {
     'upgrade': 'Upgrade Aleph.js command'
 }
 
-const helpMessage = `Aleph.js v${version}
+const helpMessage = `Aleph.js v${VERSION}
 The React Framework in deno.
 
 Docs: https://alephjs.org/docs
@@ -63,14 +63,14 @@ async function main() {
 
     // prints aleph.js version
     if (argOptions.v && command != 'upgrade') {
-        console.log(`aleph.js v${version}`)
+        console.log(`aleph.js v${VERSION}`)
         Deno.exit(0)
     }
 
     // prints aleph.js and deno version
     if (argOptions.version && command != 'upgrade') {
         const { deno, v8, typescript } = Deno.version
-        console.log(`aleph.js ${version}`)
+        console.log(`aleph.js ${VERSION}`)
         console.log(`deno ${deno}`)
         console.log(`v8 ${v8}`)
         console.log(`typescript ${typescript}`)

--- a/project.ts
+++ b/project.ts
@@ -15,7 +15,7 @@ import type { APIHandler, Config, RouterURL } from './types.ts'
 import util, { hashShort, MB, reHashJs, reHttp, reLocaleID, reMDExt, reModuleExt, reStyleModuleExt } from './util.ts'
 import { createHTMLDocument } from './vendor/deno-dom/document.ts'
 import less from './vendor/less/less.js'
-import { version } from './version.ts'
+import { VERSION } from './version.ts'
 
 interface Module {
     id: string
@@ -641,7 +641,7 @@ export class Project {
         // inject env variables
         Object.entries({
             ...this.config.env,
-            __version: version,
+            __version: VERSION,
             __buildMode: this.mode,
             __buildTarget: this.config.buildTarget,
         }).forEach(([key, value]) => Deno.env.set(key, value))
@@ -690,7 +690,7 @@ export class Project {
         const { renderPage } = await import('file://' + this.#modules.get('//deno.land/x/aleph/renderer.js')!.jsFile)
         this.#renderer = { renderPage }
 
-        log.info(colors.bold(`Aleph.js v${version}`))
+        log.info(colors.bold(`Aleph.js v${VERSION}`))
         if (this.config.__file) {
             log.info(colors.bold('- Config'))
             log.info('  ▲', this.config.__file)
@@ -986,7 +986,7 @@ export class Project {
                 }
                 dlUrl = u.toString().replace(/=(&|$)/, '$1')
             } else if (dlUrl.startsWith('https://deno.land/x/aleph/')) {
-                dlUrl = `https://deno.land/x/aleph@v${version}/` + util.trimPrefix(dlUrl, 'https://deno.land/x/aleph/')
+                dlUrl = `https://deno.land/x/aleph@v${VERSION}/` + util.trimPrefix(dlUrl, 'https://deno.land/x/aleph/')
             }
             if (mod.sourceHash === '') {
                 log.info('Download', url, dlUrl != url ? colors.dim(`• ${dlUrl}`) : '')
@@ -1117,7 +1117,7 @@ export class Project {
                     reactRefresh: this.isDev && !mod.isRemote,
                     rewriteImportPath: (path: string) => this._resolveImportURL(mod, path),
                     signUseDeno: (id: string) => {
-                        const sig = 'useDeno.' + (new Sha1()).update(id).update(version).update(Date.now().toString()).hex().slice(0, hashShort)
+                        const sig = 'useDeno.' + (new Sha1()).update(id).update(VERSION).update(Date.now().toString()).hex().slice(0, hashShort)
                         useDenos.push(sig)
                         return sig
                     }
@@ -1567,7 +1567,7 @@ function getHash(content: string | Uint8Array, checkVersion = false) {
     const sha1 = new Sha1()
     sha1.update(content)
     if (checkVersion) {
-        sha1.update(version)
+        sha1.update(VERSION)
     }
     return sha1.hex()
 }

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.2.28'
+export const VERSION = '0.2.28'


### PR DESCRIPTION
This is [the convention of the Deno standard library](https://github.com/denoland/deno/blob/1728b3ba1972faf532f261d2a7cfd6130d0f548f/std/version.ts#L8), so I think it makes sense to do the same thing here.