### PR TITLE
refactor: use div instead of main

### DIFF
--- a/framework/react/bootstrap.ts
+++ b/framework/react/bootstrap.ts
@@ -57,7 +57,7 @@ export default async function bootstrap({ baseUrl, defaultLocale, locales, route
             pageComponentTree
         }
     )
-    const mountPoint = document.querySelector('main')
+    const mountPoint = document.getElementById('__aleph')
     if (renderMode === 'ssr') {
         hydrate(rootEl, mountPoint)
     } else {

--- a/server/project.ts
+++ b/server/project.ts
@@ -229,7 +229,7 @@ export class Project {
                 ...this._getPreloadScripts()
             ],
             head: customLoading?.head || [],
-            body: `<main>${customLoading?.body || ''}</main>`,
+            body: `<div id="__aleph">${customLoading?.body || ''}</div>`,
             minify: !this.isDev
         })
         return html


### PR DESCRIPTION
use a `<div id="__aleph">` instead of a `main` tag to allow for stuff like `<header>` and `<footer>` while remaining semantically correct.