### PR TITLE
fix: rename Appliaction to Application

### DIFF
--- a/cli/build.ts
+++ b/cli/build.ts
@@ -1,4 +1,4 @@
-import { Appliaction } from '../server/mod.ts'
+import { Application } from '../server/mod.ts'
 
 export const helpMessage = `
 Usage:
@@ -14,7 +14,7 @@ Options:
 `
 
 export default async function (workingDir: string, options: Record<string, string | boolean>) {
-    const app = new Appliaction(workingDir, 'production', Boolean(options.r || options.reload))
+    const app = new Application(workingDir, 'production', Boolean(options.r || options.reload))
     await app.build()
     Deno.exit(0)
 }

--- a/cli/dev.ts
+++ b/cli/dev.ts
@@ -1,4 +1,4 @@
-import { Appliaction, parsePortNumber, serve } from '../server/mod.ts'
+import { Application, parsePortNumber, serve } from '../server/mod.ts'
 
 export const helpMessage = `
 Usage:
@@ -16,6 +16,6 @@ Options:
 
 export default async function (workingDir: string, options: Record<string, string | boolean>) {
     const port = parsePortNumber(String(options.p || options.port || '8080'))
-    const app = new Appliaction(workingDir, 'development', Boolean(options.r || options.reload))
+    const app = new Application(workingDir, 'development', Boolean(options.r || options.reload))
     serve('localhost', port, app)
 }

--- a/cli/start.ts
+++ b/cli/start.ts
@@ -1,4 +1,4 @@
-import { Appliaction, parsePortNumber, serve } from '../server/mod.ts'
+import { Application, parsePortNumber, serve } from '../server/mod.ts'
 
 export const helpMessage = `
 Usage:
@@ -18,6 +18,6 @@ Options:
 export default async function (workingDir: string, options: Record<string, string | boolean>) {
     const host = String(options.hn || options.hostname || 'localhost')
     const port = parsePortNumber(String(options.p || options.port || '8080'))
-    const app = new Appliaction(workingDir, 'production', Boolean(options.r || options.reload))
+    const app = new Application(workingDir, 'production', Boolean(options.r || options.reload))
     serve(host, port, app)
 }

--- a/server/app.ts
+++ b/server/app.ts
@@ -13,9 +13,9 @@ import { Request } from './api.ts'
 import { AlephRuntimeCode, cleanupCompilation, createHtml, fixImportMap, formatBytesWithColor, getAlephPkgUrl, getRelativePath, reFullVersion, reHashJs, reHashResolve, reLocaleID, respondErrorJSON } from './util.ts'
 
 /**
- * The Aleph Server Appliaction class.
+ * The Aleph Server Application class.
  */
-export class Appliaction {
+export class Application {
     readonly workingDir: string
     readonly mode: 'development' | 'production'
     readonly config: Readonly<Required<Config>>

--- a/server/server.ts
+++ b/server/server.ts
@@ -5,16 +5,16 @@ import log from '../shared/log.ts'
 import util from '../shared/util.ts'
 import type { ServerRequest } from '../types.ts'
 import { Request } from './api.ts'
-import { Appliaction } from './app.ts'
+import { Application } from './app.ts'
 import { getContentType } from './mime.ts'
 import { createHtml, reHashJs } from './util.ts'
 
 /** The Aleph Server class. */
 export class Server {
-    #app: Appliaction
+    #app: Application
     #ready: boolean
 
-    constructor(app: Appliaction) {
+    constructor(app: Application) {
         this.#app = app
         this.#ready = false
     }
@@ -151,7 +151,7 @@ export class Server {
 }
 
 /** start a standard aleph server. */
-export async function serve(hostname: string, port: number, app: Appliaction) {
+export async function serve(hostname: string, port: number, app: Application) {
     const server = new Server(app)
     await app.ready
     while (true) {


### PR DESCRIPTION
Hi there!Thanks for the amazing job on this. I've been using it and it works great, for such a short time! I also have a few ideas and plan to contribute back.

While browsing through the code I found out that the class exported by server had an apparent typo, it was `Appliaction` instead of `Application`.

This PR fixes it. Since it's an exported file in `server`, I don't know if anyone's using it by directly importing the file, but since it isn't exported in `mod.ts`, it should be fine.

**Note**: Another thing I noticed is that this repo isn't formatted according to `deno fmt`, should it?