### PR TITLE
[157]Fix vscode setting on init cli

### DIFF
--- a/cli/init.ts
+++ b/cli/init.ts
@@ -76,7 +76,7 @@ export default async function (nameArg?: string) {
     const settigns = {
       'deno.enable': true,
       'deno.unstable': true,
-      'deno.import_map': './import_map.json'
+      'deno.importMap': './import_map.json'
     }
     await ensureDir(path.join(name, '.vscode'))
     await Promise.all([


### PR DESCRIPTION
#157 

- Fix vscode setting `deno.impot_map` to `deno.importMap`