### PR TITLE
Allow setting revalidate to 0

### DIFF
--- a/framework/react/hooks.ts
+++ b/framework/react/hooks.ts
@@ -40,7 +40,7 @@ export function useDeno<T = any>(callback: () => (T | Promise<T>), revalidate?: 
     const dataUrl = 'pagedata://' + pathname
     const eventName = 'useDeno-' + dataUrl
     const key = dataUrl + '#' + id
-    const expires = revalidate ? Date.now() + revalidate * 1000 : 0
+    const expires = typeof revalidate === 'number' ? Date.now() + revalidate * 1000 : 0
     const renderingDataCache = global['rendering-' + dataUrl]
     if (renderingDataCache && key in renderingDataCache) {
       return renderingDataCache[key] // 2+ pass

--- a/framework/react/hooks.ts
+++ b/framework/react/hooks.ts
@@ -40,7 +40,7 @@ export function useDeno<T = any>(callback: () => (T | Promise<T>), revalidate?: 
     const dataUrl = 'pagedata://' + pathname
     const eventName = 'useDeno-' + dataUrl
     const key = dataUrl + '#' + id
-    const expires = typeof revalidate === 'number' ? Date.now() + revalidate * 1000 : 0
+    const expires = typeof revalidate === 'number' && !isNaN(revalidate) ? Date.now() + revalidate * 1000 : 0
     const renderingDataCache = global['rendering-' + dataUrl]
     if (renderingDataCache && key in renderingDataCache) {
       return renderingDataCache[key] // 2+ pass


### PR DESCRIPTION
This makes useDeno always refresh on each request.

It was also possible to pass a small value, e.g., `0.0000001`, but this is less hackish.