### PR TITLE
Remove extra slash on Windows OS #201

### DIFF
--- a/shared/fs.ts
+++ b/shared/fs.ts
@@ -4,6 +4,7 @@ import { ensureDir } from 'https://deno.land/std@0.90.0/fs/ensure_dir.ts'
 /* check whether or not the given path exists as a directory. */
 export async function existsDir(path: string): Promise<boolean> {
   try {
+    if (path.startsWith('/') && Deno.build.os === "windows") path = path.substr(1)
     const fi = await Deno.lstat(path)
     if (fi.isDirectory) {
       return true
@@ -20,6 +21,7 @@ export async function existsDir(path: string): Promise<boolean> {
 /* check whether or not the given path exists as a directory. */
 export function existsDirSync(path: string) {
   try {
+    if (path.startsWith('/') && Deno.build.os === "windows") path = path.substr(1)
     const fi = Deno.lstatSync(path)
     if (fi.isDirectory) {
       return true
@@ -36,6 +38,7 @@ export function existsDirSync(path: string) {
 /* check whether or not the given path exists as regular file. */
 export async function existsFile(path: string): Promise<boolean> {
   try {
+    if (path.startsWith('/') && Deno.build.os === "windows") path = path.substr(1)
     const fi = await Deno.lstat(path)
     if (fi.isFile) {
       return true
@@ -52,6 +55,7 @@ export async function existsFile(path: string): Promise<boolean> {
 /* check whether or not the given path exists as regular file. */
 export function existsFileSync(path: string) {
   try {
+    if (path.startsWith('/') && Deno.build.os === "windows") path = path.substr(1)
     const fi = Deno.lstatSync(path)
     if (fi.isFile) {
       return true
@@ -67,6 +71,7 @@ export function existsFileSync(path: string) {
 
 /** ensure and write a text file. */
 export async function ensureTextFile(name: string, content: string): Promise<void> {
+  if (name.startsWith('/') && Deno.build.os === "windows") name = name.substr(1)
   const dir = dirname(name)
   await ensureDir(dir)
   await Deno.writeTextFile(name, content)
@@ -75,6 +80,7 @@ export async function ensureTextFile(name: string, content: string): Promise<voi
 /** remove the file if it exists. */
 export async function lazyRemove(name: string, options?: { recursive?: boolean }): Promise<void> {
   try {
+    if (name.startsWith('/') && Deno.build.os === "windows") name = name.substr(1)
     await Deno.remove(name, options)
   } catch (err) {
     if (err instanceof Deno.errors.NotFound) {

--- a/shared/util.ts
+++ b/shared/util.ts
@@ -75,7 +75,8 @@ export default {
       }, [] as Array<string>)
   },
   cleanPath(path: string): string {
-    return '/' + this.splitPath(path).join('/')
+    return (Deno.build.os !== "windows" ? '/' : '') +
+      this.splitPath(path).join('/')
   },
   debounce<T extends Function>(callback: T, delay: number): T {
     let timer: number | null = null

--- a/shared/util.ts
+++ b/shared/util.ts
@@ -75,8 +75,7 @@ export default {
       }, [] as Array<string>)
   },
   cleanPath(path: string): string {
-    return (Deno.build.os !== "windows" ? '/' : '') +
-      this.splitPath(path).join('/')
+    return '/' + this.splitPath(path).join('/')
   },
   debounce<T extends Function>(callback: T, delay: number): T {
     let timer: number | null = null


### PR DESCRIPTION
Hi, thanks for this great project! 

After debuging I found this extra slash at initial path. When `ensureText` try write in disk get this message error in windows.

I made a "dirty" fix just to works on windows... maybe you have a much better solution