### PR TITLE
fix for outputDir

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -763,11 +763,12 @@ export class Application implements ServerApplication {
   /** build the application to a static site(SSG) */
   async build() {
     const start = performance.now()
-    const outputDir = this.outputDir
-    const distDir = join(outputDir, '_aleph')
 
     // wait for app ready
     await this.ready
+
+    const outputDir = this.outputDir
+    const distDir = join(outputDir, '_aleph')
 
     // clear previous build
     if (existsDirSync(outputDir)) {


### PR DESCRIPTION
The specified `outputDir` does not work partially.

```
$ deno install --unstable -A -f -n aleph https://deno.land/x/aleph/cli.ts
$ aleph --version
aleph.js 0.3.0-alpha.28
deno 1.8.3
v8 9.0.257.3
typescript 4.2.2
$ aleph init hello
$ cd hello

$ echo '
import type { Config } from "https://deno.land/x/aleph@v0.3.0-alpha.28/types.ts"

export default (): Config => ({
  outputDir: "/docs"  
})
' > aleph.config.ts

$ aleph build
$ ls dist
_aleph  logo.svg
$ ls docs
404.html  _aleph  index.html
```

I expect the following:
```
$ ls dist
ls: cannot access 'dist': No such file or directory
$ ls docs
404.html  _aleph  index.html  logo.svg
```

I fixed it.
I would appreciate it if you could check it.

