### PR TITLE
feat(server):  Add `acceptsLanguages`  returns languages, accepted by the requestor

### DIFF
--- a/server/api.ts
+++ b/server/api.ts
@@ -4,6 +4,7 @@ import type { MultipartFormData } from 'https://deno.land/std@0.92.0/mime/multip
 import { MultipartReader } from 'https://deno.land/std@0.92.0/mime/multipart.ts'
 import log from '../shared/log.ts'
 import type { APIRequest, ServerRequest, ServerResponse } from '../types.ts'
+import { preferredLanguages } from './negotiation.ts'
 
 let brotli: ((data: Uint8Array) => Uint8Array) | null = null
 let gzip: ((data: Uint8Array) => Uint8Array) | null = null
@@ -139,6 +140,20 @@ export class Request implements APIRequest {
     this.#resp.status = status
     this.#resp.headers.set("Location", encodeURI(url))
     return this
+  }
+
+  acceptsLanguages(): string[] | undefined
+  acceptsLanguages(...langs: string[]): string[] | string | undefined {
+    const acceptLanguageValue = this.#req.headers.get(
+      "Accept-Language",
+    )
+    if (!acceptLanguageValue) {
+      return
+    }
+    if (langs.length) {
+      return preferredLanguages(acceptLanguageValue, langs)[0]
+    }
+    return preferredLanguages(acceptLanguageValue)
   }
 
   async send(data?: string | Uint8Array | ArrayBuffer, contentType?: string): Promise<void> {

--- a/server/negotiation.ts
+++ b/server/negotiation.ts
@@ -1,0 +1,158 @@
+/*!
+ * Adapted directly from oak at https://github.com/oakserver/oak
+ * which is licensed as follows:
+ *
+ * (The MIT License)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * 'Software'), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+interface LanaguageSpecificity extends Specificity {
+  prefix: string
+  suffix?: string
+  full: string
+}
+
+interface Specificity {
+  i: number
+  o?: number
+  q: number
+  s?: number
+}
+
+function compareSpecs(a: Specificity, b: Specificity): number {
+  return (
+    b.q - a.q ||
+    (b.s ?? 0) - (a.s ?? 0) ||
+    (a.o ?? 0) - (b.o ?? 0) ||
+    a.i - b.i ||
+    0
+  )
+}
+
+function isQuality(spec: Specificity): boolean {
+  return spec.q > 0
+}
+
+const SIMPLE_LANGUAGE_REGEXP = /^\s*([^\s\-;]+)(?:-([^\s;]+))?\s*(?:;(.*))?$/
+
+function parseLanguage(
+  str: string,
+  i: number,
+): LanaguageSpecificity | undefined {
+  const match = SIMPLE_LANGUAGE_REGEXP.exec(str)
+  if (!match) {
+    return undefined
+  }
+
+  const [, prefix, suffix] = match
+  const full = suffix ? `${prefix}-${suffix}` : prefix
+
+  let q = 1
+  if (match[3]) {
+    const params = match[3].split(";")
+    for (const param of params) {
+      const [key, value] = param.trim().split("=")
+      if (key === "q") {
+        q = parseFloat(value)
+        break
+      }
+    }
+  }
+
+  return { prefix, suffix, full, q, i }
+}
+
+function parseAcceptLanguage(accept: string): LanaguageSpecificity[] {
+  const accepts = accept.split(",")
+  const result: LanaguageSpecificity[] = []
+
+  for (let i = 0; i < accepts.length; i++) {
+    const language = parseLanguage(accepts[i].trim(), i)
+    if (language) {
+      result.push(language)
+    }
+  }
+  return result
+}
+
+function specify(
+  language: string,
+  spec: LanaguageSpecificity,
+  i: number,
+): Specificity | undefined {
+  const p = parseLanguage(language, i)
+  if (!p) {
+    return undefined
+  }
+  let s = 0
+  if (spec.full.toLowerCase() === p.full.toLowerCase()) {
+    s |= 4
+  } else if (spec.prefix.toLowerCase() === p.prefix.toLowerCase()) {
+    s |= 2
+  } else if (spec.full.toLowerCase() === p.prefix.toLowerCase()) {
+    s |= 1
+  } else if (spec.full !== "*") {
+    return
+  }
+
+  return { i, o: spec.i, q: spec.q, s }
+}
+
+function getLanguagePriority(
+  language: string,
+  accepted: LanaguageSpecificity[],
+  index: number,
+): Specificity {
+  let priority: Specificity = { i: -1, o: -1, q: 0, s: 0 }
+  for (const accepts of accepted) {
+    const spec = specify(language, accepts, index)
+    if (
+      spec &&
+      ((priority.s ?? 0) - (spec.s ?? 0) || priority.q - spec.q ||
+        (priority.o ?? 0) - (spec.o ?? 0)) < 0
+    ) {
+      priority = spec
+    }
+  }
+  return priority
+}
+
+export function preferredLanguages(
+  accept = "*",
+  provided?: string[],
+): string[] {
+  const accepts = parseAcceptLanguage(accept)
+
+  if (!provided) {
+    return accepts
+      .filter(isQuality)
+      .sort(compareSpecs)
+      .map((spec) => spec.full)
+  }
+
+  const priorities = provided
+    .map((type, index) => getLanguagePriority(type, accepts, index))
+
+  return priorities
+    .filter(isQuality)
+    .sort(compareSpecs)
+    .map((priority) => provided[priorities.indexOf(priority)])
+}

--- a/types.ts
+++ b/types.ts
@@ -185,6 +185,9 @@ export interface APIRequest extends ServerRequest {
   json(data: any): Promise<void>
   /** `redirect` replies to redirect the client to another URL with optional response `status` defaulting to 302. */
   redirect(url: string, status?: Status): this
+  /** `acceptsLanguages` replies to return languages, accepted by the requestor. */
+  acceptsLanguages(): string[] | undefined
+  acceptsLanguages(...langs: string[]): string[] | string | undefined
 }
 
 /**


### PR DESCRIPTION
 Returns languages, accepted by the requestor, in order of preference.  If there are no languages supplied by the requestor, `undefined` is returned