### PR TITLE
Anchor tag respects modifiers

### DIFF
--- a/examples/anchor-links/app.tsx
+++ b/examples/anchor-links/app.tsx
@@ -1,0 +1,35 @@
+import React, { ComponentType } from 'react'
+
+const links = {
+  'Home': '/',
+  'About': '/about',
+  'Query 0': '/query',
+  'Query 1': '/query?q=hello&limit=10&offset=20',
+  'Pink': '/colors/pink',
+  'Orange': '/colors/orange',
+  'Teal': '/colors/teal',
+  'Dark Blue': '/colors/darkblue?text=yellow',
+  'Dark Green': '/colors/darkgreen?text=orange',
+}
+
+export default function App({ Page, pageProps }: { Page: ComponentType<any>, pageProps: any }) {
+  return (
+    <main>
+      <head>
+        <meta name="viewport" content="width=device-width" />
+        <style>{`
+          body {
+            font-family: sans-serif;
+          }
+          nav a {
+            margin: 10px;
+          }
+        `}</style>
+      </head>
+      <nav>
+        {Object.entries(links).map(([name, link]) => <a key={name} href={link}>{name}</a>)}
+      </nav>
+      <Page {...pageProps} />
+    </main>
+  )
+}

--- a/examples/anchor-links/pages/about.tsx
+++ b/examples/anchor-links/pages/about.tsx
@@ -1,0 +1,22 @@
+import { useDeno } from "framework/react"
+import React from "react"
+
+export default function About() {
+  const version = useDeno(() => Deno.version.deno)
+  return (
+    <div>
+      <head>
+        <title>About</title>
+        <style>{`
+          body {
+            background: pink;
+          }
+        `}</style>
+      </head>
+      <div>
+        <h1>About page</h1>
+        <p>Deno version: {version}</p>
+      </div>
+    </div>
+  )
+}

--- a/examples/anchor-links/pages/colors/[name].tsx
+++ b/examples/anchor-links/pages/colors/[name].tsx
@@ -1,0 +1,27 @@
+import { useRouter } from "framework/react"
+import React from "react"
+
+export default function Query() {
+  const router = useRouter()
+  const color = router.params.name || 'white'
+  const textColor = router.query.get('text') || 'black'
+  return (
+    <div>
+      <head>
+        <title>Color: {color}</title>
+        <style>{`
+          body {
+            background: ${color};
+            color: ${textColor};
+          }
+          nav a {
+            color: ${textColor};
+          }
+        `}</style>
+      </head>
+      <div>
+        <h1>{color}</h1>
+      </div>
+    </div>
+  )
+}

--- a/examples/anchor-links/pages/index.tsx
+++ b/examples/anchor-links/pages/index.tsx
@@ -1,0 +1,15 @@
+import { useDeno } from 'framework/react'
+import React from 'react'
+
+export default function Home() {
+  return (
+    <div>
+      <head>
+        <title>Home</title>
+      </head>
+      <div>
+        <h1>Home page</h1>
+      </div>
+    </div>
+  )
+}

--- a/examples/anchor-links/pages/query.tsx
+++ b/examples/anchor-links/pages/query.tsx
@@ -1,0 +1,30 @@
+import { useDeno, useRouter } from "framework/react"
+import React from "react"
+
+export default function Query() {
+  const router = useRouter()
+  const debug = useDeno(() => {
+    const q = Object.fromEntries(router.query.entries())
+    return JSON.stringify(q, undefined, 2)
+  })
+  return (
+    <div>
+      <head>
+        <title>Query</title>
+        <style>{`
+          body {
+            background: #333;
+            color: lightgreen;
+          }
+          nav a {
+            color: teal;
+          }
+        `}</style>
+      </head>
+      <div>
+        <h1>Query:</h1>
+        <pre>{debug}</pre>
+      </div>
+    </div>
+  )
+}

--- a/framework/react/components/Anchor.ts
+++ b/framework/react/components/Anchor.ts
@@ -113,7 +113,7 @@ export default function Anchor(props: AnchorProps) {
     if (util.isFunction(props.onMouseEnter)) {
       props.onMouseEnter(e)
     }
-    if (e.defaultPrevented) {
+    if (e.defaultPrevented || isModifiedEvent(e)) {
       return
     }
     e.preventDefault()
@@ -140,5 +140,18 @@ export default function Anchor(props: AnchorProps) {
       'aria-current': ariaCurrent
     },
     children
+  )
+}
+
+function isModifiedEvent(event: React.MouseEvent): boolean {
+  const { target } = event.currentTarget as any
+  const nativeEvent = event.nativeEvent as any
+  return (
+    (target && target !== '_self') ||
+    event.metaKey ||
+    event.ctrlKey ||
+    event.shiftKey ||
+    event.altKey || // triggers resource download
+    (nativeEvent && nativeEvent.which === 2)
   )
 }


### PR DESCRIPTION
Taken from next.js:
https://github.com/vercel/next.js/blob/canary/packages/next/client/link.tsx#L89

Also hijacks the `hello-world-src-dir` example for testing navigation behavior.  This example demonstrates bugs #230 (and maybe also #217) if you:

* Click `About Blank` to open in new tab
* Switch to new tab and hover over `Back home`
* index.css stylesheet gets loaded and page appearance changes.

Anyway it would be nice to have an example either in this repo or separate repo that exercises all the navigation + data loading features for testing purposes.