### PR TITLE
Fix the condition of meta.className

### DIFF
--- a/plugins/markdown.ts
+++ b/plugins/markdown.ts
@@ -28,7 +28,7 @@ export default (): LoaderPlugin => {
       const framework = Deno.env.get('ALEPH_FRAMEWORK')
       const props = {
         id: util.isString(meta.id) ? meta.id : undefined,
-        className: util.isString(meta.id) ? meta.className : undefined,
+        className: util.isString(meta.className) ? meta.className : undefined,
         style: util.isPlainObject(meta.style) ? meta.style : undefined,
       }
 


### PR DESCRIPTION
I thought the condition of `className` in `markdown.ts` was not correct, so I fixed it.