### PR TITLE
react: fix detection of react components

### DIFF
--- a/framework/react/helper.ts
+++ b/framework/react/helper.ts
@@ -9,26 +9,7 @@ export const inDeno = typeof Deno !== 'undefined' && typeof Deno.version?.deno =
 export function isLikelyReactComponent(type: any, strict = true): Boolean {
   switch (typeof type) {
     case 'function':
-      if (type.prototype != null) {
-        if (type.prototype.isReactComponent) {
-          return true
-        }
-        const ownNames = Object.getOwnPropertyNames(type.prototype)
-        if (ownNames.length > 1 || ownNames[0] !== 'constructor') {
-          return false
-        }
-      }
-      if (!strict) {
-        // don't check component name
-        return true
-      }
-      const { __ALEPH: ALEPH } = window as any
-      if (ALEPH) {
-        // in bundle mode, the component names have been compressed.
-        return true
-      }
-      const name = type.displayName || type.name
-      return typeof name === 'string' && /^[A-Z]/.test(name)
+      return true
     case 'object':
       if (type != null) {
         switch (type.$$typeof) {


### PR DESCRIPTION
Currently, only react components with fully uppercase names are detected as react components.

Unless I'm misunderstanding something fundamentally about how react/aleph.js work, then it should also match any names with both uppercase and lowercase letters.