### PR TITLE
Remove deadcode from `commands/analyze.ts`

### DIFF
--- a/commands/analyze.ts
+++ b/commands/analyze.ts
@@ -33,13 +33,4 @@ export default async function (workingDir: string, flags: Record<string, any>) {
       body: JSON.stringify(entries)
     })
   }
-  const server = Deno.listen({ port })
-  log.info(`Server ready on http://localhost:${port}`)
-
-  for await (const conn of server) {
-    (async () => {
-      const httpConn = Deno.serveHttp(conn)
-      for await (const requestEvent of httpConn) { }
-    })()
-  }
 }


### PR DESCRIPTION
It seems that `commands/analyze.ts` contains code that will never be executed, so this PR removes it.