### PR TITLE
Fix SSR data passing

### DIFF
--- a/examples/hello-world-ssr/app.tsx
+++ b/examples/hello-world-ssr/app.tsx
@@ -1,0 +1,12 @@
+import React, { ComponentType } from 'react'
+
+export default function App({ Page, pageProps }: { Page: ComponentType<any>, pageProps: any }) {
+  return (
+    <main>
+      <head>
+        <meta name="viewport" content="width=device-width" />
+      </head>
+      <Page {...pageProps} />
+    </main>
+  )
+}

--- a/examples/hello-world-ssr/pages/index.tsx
+++ b/examples/hello-world-ssr/pages/index.tsx
@@ -1,0 +1,20 @@
+import React from 'https://esm.sh/react'
+import type { SSROptions } from 'https://deno.land/x/aleph/types.d.ts'
+
+export const ssr: SSROptions = {
+  props: async router => {
+    return {
+      $revalidate: 1, // revalidate props after 1 second
+      serverTime: Date.now()
+    }
+  },
+  paths: async () => {
+    return []
+  }
+}
+
+export default function Page(props) {
+  return (
+    <p>Now: {props.serverTime}</p>
+  )
+}

--- a/framework/react/bootstrap.ts
+++ b/framework/react/bootstrap.ts
@@ -19,6 +19,13 @@ export default async function bootstrap(options: BootstrapOptions) {
   const routing = new Routing({ routes, rewrites, basePath, defaultLocale, locales, redirect })
   const [url, nestedModules] = routing.createRouter()
   const components = await importPageModules(url, nestedModules)
+
+  if (renderMode === 'ssr') {
+    // restore ssr-data from HTML
+    // must be called before creating page props
+    loadSSRDataFromTag(url)
+  }
+
   const pageRoute = createPageRoute(url, components)
   const routerEl = createElement(Router, { appModule, pageRoute, routing })
   const mountPoint = document.getElementById('__aleph')
@@ -27,7 +34,6 @@ export default async function bootstrap(options: BootstrapOptions) {
     if (dataRoutes) {
       setStaticDataRoutes(dataRoutes)
     }
-    loadSSRDataFromTag(url)
     hydrate(routerEl, mountPoint)
   } else {
     render(routerEl, mountPoint)


### PR DESCRIPTION
The `ssr-data` in HTML is not passed to props, because 

* `createPageRoute` sets `ssrData` (in `pagedata://`) to page component props
* `loadSSRDataFromTag` sets `ssr-data` from HTML into memory (`pagedata://`)
* `createPageRoute` is called before `loadSSRDataFromTag` is called.
    - page component gets empty props

so,  I moved `loadSSRDataFromTag` before `createPageRoute`.

## test

`examples/hello-world-ssr` is same as [SSR sample in the document](https://alephjs.org/docs/basic-features/ssr-and-ssg).

1. run the sample
2. check the `serverTime` in HTML is passed to UI