### PR TITLE
Migrate from denolib/setup-deno to denoland/setup-deno

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Setup deno
-        uses: denolib/setup-deno@v2
+        uses: denoland/setup-deno@main
         with:
           deno-version: v1.x
 


### PR DESCRIPTION
It seems that [denolib/setup-deno](https://github.com/denolib/setup-deno) has already been archived. This PR migrates it to [the official setup-deno action](https://github.com/denoland/setup-deno).