### PR TITLE
Await renderListener callback

### DIFF
--- a/server/aleph.ts
+++ b/server/aleph.ts
@@ -644,7 +644,7 @@ export class Aleph implements IAleph {
   async #renderPage(url: RouterURL, nestedModules: string[]): Promise<[string, Record<string, SSRData> | null]> {
     let [html, data] = await this.#renderer.renderPage(url, nestedModules)
     for (const callback of this.#renderListeners) {
-      callback({ path: url.toString(), html, data })
+      await callback({ path: url.toString(), html, data })
     }
     return [buildHtml(html, !this.isDev), data]
   }


### PR DESCRIPTION
The callback is awaited in `createSPAIndexHtml()` but not in `#renderPage()`