### PR TITLE
Fix i18n routing

### DIFF
--- a/server/aleph.ts
+++ b/server/aleph.ts
@@ -105,7 +105,8 @@ export class Aleph implements IAleph {
       Object.assign(this.#importMap, getDefaultImportMap())
     }
     if (configFile) {
-      Object.assign(this.#config, await loadConfig(configFile))
+      const config = await loadConfig(configFile)
+      Object.assign(this.#config, config, config.i18n)
       this.#pageRouting = new Routing(this.#config)
     }
 
@@ -659,7 +660,7 @@ export class Aleph implements IAleph {
   async createMainJS(bundleMode = false): Promise<string> {
     const alephPkgUri = getAlephPkgUri()
     const alephPkgPath = alephPkgUri.replace('https://', '').replace('http://localhost:', 'http_localhost_')
-    const { framework, basePath: basePath, i18n: { defaultLocale } } = this.#config
+    const { framework, basePath: basePath, i18n: { defaultLocale, locales } } = this.#config
     const { routes } = this.#pageRouting
     const config: Record<string, any> = {
       basePath,
@@ -667,7 +668,7 @@ export class Aleph implements IAleph {
       routes,
       renderMode: this.#config.ssr ? 'ssr' : 'spa',
       defaultLocale,
-      locales: [],
+      locales,
       rewrites: this.#config.server.rewrites,
     }
 


### PR DESCRIPTION
I changed my code according to the "[I18N routing](https://alephjs.org/docs/basic-features/routing#i18n-routing)" in the official documentation, but it did not work correctly.

```
$ deno --version
deno 1.14.0 (release, x86_64-apple-darwin)
v8 9.4.146.15
typescript 4.4.2

$ aleph --version
aleph.js 0.3.0-beta.14
deno 1.14.0
v8 9.4.146.15
typescript 4.4.2
```

Maybe this bug is caused by a change made in [16483f9](https://github.com/alephjs/aleph.js/commit/16483f96a2020c829b951185a624645d33eb49eb#diff-8033e9b81c9757b4f6b0dffdbd5f34f7fbc5a59761f876c863768a9da20ea1b7). In this commit, [this code](https://github.com/alephjs/aleph.js/blob/16483f96a2020c829b951185a624645d33eb49eb/server/aleph.ts#L145-L146) also needed to be changed.

Check the problem by using `v0.3.0-beta.14` and making the following changes.

```ts
// ./examples/hello-world/aleph.config.ts
import type { Config } from "aleph/types.d.ts";

export default <Config> {
  i18n: {
    defaultLocale: "ja",
    locales: ["en", "ja"],
  },
};
```

```tsx
// ./examples/hello-world/app.tsx
import { useRouter } from "aleph/react";

...

const { defaultLocale, locales } = useRouter();

// Before: defaultLocale=ja locales=[]
// After: defaultLocale=ja locales=["en","ja"]
console.log(
  `defaultLocale=${defaultLocale}`,
  `locales=${JSON.stringify(locales)}`,
);

...

return (

  ...

  <a href="/en">en</a> {/* 404 */}
  <a href="/">ja</a>

  ...

);

```

Regardless of the `ssr` option, the final rendering result will be as follows.

|Before (https://github.com/alephjs/aleph.js/commit/e47d1edd844856af22dc8fc3b26ac5125e176047)|After (https://github.com/calmery/aleph.js/commit/3e25d5d98ea30155e34d95b0f788d91d66059e46)|
|:-:|:-:|
|![Before](https://user-images.githubusercontent.com/12670155/133805723-61c0e1dd-4824-4cb6-b460-9f5fea58a569.png)|![After](https://user-images.githubusercontent.com/12670155/133805752-cca2af7c-0d21-4176-ae30-af3abfe63d9e.png)|

After the fix, I have confirmed that i18n routing works correctly with the following command.

```
$ ALEPH_DEV=true deno run -A --unstable --location=http://localhost cli.ts dev ./examples/hello-world -L debug
```