### PR TITLE
Fix the `lang` attribute of the <html> tag generated by SSG

### DIFF
--- a/server/aleph.ts
+++ b/server/aleph.ts
@@ -1496,7 +1496,7 @@ export class Aleph implements IAleph {
     }
 
     // render route pages
-    await Promise.all(Array.from(paths).map(loc => ([loc, ...locales.map(locale => ({ ...loc, pathname: locale + loc.pathname }))])).flat().map(async ({ pathname, search }) => {
+    await Promise.all(Array.from(paths).map(loc => ([loc, ...locales.map(locale => ({ ...loc, pathname: '/' + locale + loc.pathname }))])).flat().map(async ({ pathname, search }) => {
       if (this.isSSRable(pathname)) {
         const [router, nestedModules] = this.#pageRouting.createRouter({ pathname, search })
         if (router.routePath !== '') {


### PR DESCRIPTION
Regardless of the `i18n.locales` option in aleph.config.ts, all language generation results using SSG use `defaultLocale` for the `lang` attribute of \<html\> tag. The cause of this problem is that the URL received by the `_createRouter` function does not have a `/` at the beginning, which does not work as expected. ([framework/core/routing.ts#L139-L146](https://github.com/alephjs/aleph.js/blob/55d80d13df7b17a71df946dd8c322d1ae4cc59a8/framework/core/routing.ts#L139-L146))

```ts
// examples/hello-world-i18n/aleph.config.ts
import type { Config } from 'aleph/types'

export default (): Config => ({
  ssr: true, // This problem only occurs when the `ssr` option is `true`.
  i18n: {
    defaultLocale: 'en',
    locales: ['en', 'zh']
  }
})
```

```
$ ALEPH_DEV=true deno run -A --unstable --location=http://localhost cli.ts build ./examples/hello-world-i18n -L debug
```

Before the change.

```html
<!-- examples/hello-world-i18n/dist/index.html -->
<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8" />...</html>
```

```html
<!-- examples/hello-world-i18n/dist/zh/index.html -->
<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8" />...</html>
```

After the change.

```html
<!-- examples/hello-world-i18n/dist/index.html -->
<!DOCTYPE html><html lang="en"><head><meta charSet="utf-8" />...</html>
```

```html
<!-- examples/hello-world-i18n/dist/zh/index.html -->
<!DOCTYPE html><html lang="zh"><head><meta charSet="utf-8" />...</html>
```