### PR TITLE
Proposal: Add Props generic type to SSROptions

### DIFF
--- a/examples/hello-world-ssr/pages/index.tsx
+++ b/examples/hello-world-ssr/pages/index.tsx
@@ -1,7 +1,11 @@
-import React from 'https://esm.sh/react'
+import React, { FC } from 'https://esm.sh/react'
 import type { SSROptions } from 'https://deno.land/x/aleph/types.d.ts'
 
-export const ssr: SSROptions = {
+type Props = {
+  serverTime: number
+}
+
+export const ssr: SSROptions<Props> = {
   props: async router => {
     return {
       $revalidate: 1, // revalidate props after 1 second
@@ -13,8 +17,10 @@ export const ssr: SSROptions = {
   }
 }
 
-export default function Page(props) {
+const Page: FC<Props> = (props) => {
   return (
     <p>Now: {props.serverTime}</p>
   )
 }
+
+export default Page

--- a/types.d.ts
+++ b/types.d.ts
@@ -236,16 +236,15 @@ export type GlobalSSROptions = {
 /**
  * The **SSR** props.
  */
-export type SSRProps = {
-  [key: string]: any
+export type SSRProps<Props> = Props & {
   $revalidate?: number
 }
 
 /**
  * The **SSR** options for pages.
  */
-export type SSROptions = {
-  props?(router: RouterURL): (SSRProps | Promise<SSRProps>)
+export type SSROptions<Props = {}> = {
+  props?(router: RouterURL): (SSRProps<Props> | Promise<SSRProps<Props>>)
   paths?(): (string[] | Promise<string[]>)
 }
 


### PR DESCRIPTION
This change is a proposal to add a generic type parameter to the `SSROptions` type that,
as a result, provides a type for the returned props object. This models
after React's type generics for component types.

See `examples/hello-world-ssr/pages/index.tsx` for usage example.