### PR TITLE
More useful Error in import onerror

### DIFF
--- a/bundler/mod.ts
+++ b/bundler/mod.ts
@@ -37,7 +37,9 @@ export const bundlerRuntimeCode = `
         e.onload = function() {
           y(a[s]);
         };
-        e.onerror = n;
+        e.onerror = function(g) {
+          n(new Error('script failed to load ' + g.target.src));
+        };
         p += f;
         if (r) {
           p += '?t=' + (new Date).getTime();


### PR DESCRIPTION
Improve the error message when a `<script>` tag fails to load.

See https://github.com/getsentry/sentry-javascript/issues/2546#issuecomment-703331367