### PR TITLE
Ignoring .aleph folder for lint and fmt scripts

### DIFF
--- a/commands/init.ts
+++ b/commands/init.ts
@@ -125,8 +125,16 @@ export default async function (
       ],
       "jsx": "react"
     },
-    "lint": {},
-    "format": {},
+    "lint": {
+      "files": {
+        "exclude": [".aleph/"]
+      },
+    },
+    "fmt": {
+      "files": {
+        "exclude": [".aleph/"]
+      },
+    },
   }
   await Promise.all([
     Deno.writeTextFile(join(cwd, name, '.gitignore'), gitignore.join('\n')),


### PR DESCRIPTION
This PR configure deno to ignore the `.aleph` folder when linting and formatting.

* I also renamed the `"format"` key to `"fmt"`

It closes #361 