### PR TITLE
fix: avoid setting userAgent when it's already set

### DIFF
--- a/server/mod.ts
+++ b/server/mod.ts
@@ -400,9 +400,10 @@ export const serve = (options: ServerOptions = {}) => {
     language: "en",
     languages: ["en"],
     onLine: true,
-    userAgent: `Deno/${Deno.version?.deno || "deploy"}`,
     vendor: "Deno Land Inc.",
   });
+  // deno-lint-ignore no-explicit-any
+  (globalThis.navigator as any).userAgent ??= `Deno/${Deno.version?.deno || "deploy"}`;
 
   // set log level if specified
   if (logLevel) {


### PR DESCRIPTION
navigator.userAgent has become getter-only property at https://github.com/denoland/deno/pull/14415, and we can't set it anymore. This PR avoids error with that