### PR TITLE
fix: propagate SIGINT to child process

### DIFF
--- a/cli.ts
+++ b/cli.ts
@@ -209,6 +209,9 @@ async function run(command: string, options: RunOptions) {
   const p = Deno.run({ cmd, stdout: "piped", stderr: "piped" });
   pipe(p.stdout, Deno.stdout);
   pipe(p.stderr, Deno.stderr);
+  addEventListener("unload", () => {
+    p.kill("SIGTERM");
+  });
   const { code } = await p.status();
   Deno.exit(code);
 }

--- a/cli.ts
+++ b/cli.ts
@@ -210,6 +210,7 @@ async function run(command: string, options: RunOptions) {
   pipe(p.stdout, Deno.stdout);
   pipe(p.stderr, Deno.stderr);
   addEventListener("unload", () => {
+    console.log("killing child")
     p.kill("SIGTERM");
   });
   const { code } = await p.status();

--- a/cli.ts
+++ b/cli.ts
@@ -209,9 +209,9 @@ async function run(command: string, options: RunOptions) {
   const p = Deno.run({ cmd, stdout: "piped", stderr: "piped" });
   pipe(p.stdout, Deno.stdout);
   pipe(p.stderr, Deno.stderr);
-  addEventListener("unload", () => {
-    console.log("killing child")
-    p.kill("SIGTERM");
+  Deno.addSignalListener("SIGINT", () => {
+    p.kill("SIGINT");
+    Deno.exit(2);
   });
   const { code } = await p.status();
   Deno.exit(code);


### PR DESCRIPTION
Ctrl-C is propagated to child processes when you invoke the cli from your terminal, but if you start aleph in testing, then SIGINT (Ctrl-C) is not sent to child process. That causes the child process remaining after test runs.

This PR fixes the above issue.

[This node.js issue](https://github.com/nodejs/node/issues/13538) discusses a similar problem. See especially [this comment](https://github.com/nodejs/node/issues/13538#issuecomment-307799666)