### PR TITLE
Fix TS2345 [ERROR] when `port` option is used

### DIFF
--- a/server/mod.ts
+++ b/server/mod.ts
@@ -24,6 +24,7 @@ export type ServerOptions = Omit<ServeInit, "onError"> & {
   fetch?: FetchHandler;
   ssr?: SSR;
   onError?: ErrorCallback;
+  port?: number;
 } & AlephConfig;
 
 export const serve = (options: ServerOptions = {}) => {


### PR DESCRIPTION
This should fix an error during `deno cache ...`

```ts
// server.ts
import { serve } from "https://deno.land/x/aleph@1.0.0-alpha.49/server/mod.ts";

// cannot use { port: 8000 } due to type error.
// ... let it default to 8080
serve({
  port: 8000,
});
```

```console
λ  deno cache server.ts
...
error: TS2345 [ERROR]: Argument of type '{ port: number; }' is not assignable to parameter of type 'ServerOptions'.
  Object literal may only specify known properties, and 'port' does not exist in type 'ServerOptions'.
serve({ port: 8000 })
```