### PR TITLE
fix: Relative returns \ on Windows OS

### DIFF
--- a/commands/dev.ts
+++ b/commands/dev.ts
@@ -106,7 +106,7 @@ if (import.meta.main) {
 
   log.info(`Watching files for changes...`);
   watchFs(cwd, async (kind, path) => {
-    const specifier = "./" + relative(cwd, path);
+    const specifier = "./" + relative(cwd, path).replaceAll("\\", "/");
     const clientDependencyGraph: DependencyGraph | undefined = Reflect.get(globalThis, "__ALEPH_CLIENT_DEP_GRAPH");
     const serverDependencyGraph: DependencyGraph | undefined = Reflect.get(globalThis, "__ALEPH_SERVER_DEP_GRAPH");
     if (kind === "remove") {


### PR DESCRIPTION
specifier does not match, hmr is not available on windows