### PR TITLE
Uppercase HTTP method tokens in fetch, as per RFCs 2616 and 7231

### DIFF
--- a/framework/react/data.ts
+++ b/framework/react/data.ts
@@ -212,7 +212,9 @@ function send(method: HttpMethod, href: string, data: unknown): Promise<Response
       headers.append("Content-Type", "application/json; charset=utf-8");
     }
   }
-  return fetch(href, { method, body, headers });
+  // NOTE: RFC 2616 section 5.1.1 and RFC 7231 section 4.1 state that the method
+  // token is case-sensitive, and all tokens are by convention all-uppercase.
+  return fetch(href, { method: method.toUpperCase(), body, headers });
 }
 
 function shallowClone<T>(obj: T): T {

--- a/framework/vue/data.ts
+++ b/framework/vue/data.ts
@@ -194,7 +194,9 @@ function send(method: HttpMethod, href: string, data: unknown) {
       headers.append("Content-Type", "application/json; charset=utf-8");
     }
   }
-  return fetch(href, { method, body, headers });
+  // NOTE: RFC 2616 section 5.1.1 and RFC 7231 section 4.1 state that the method
+  // token is case-sensitive, and all tokens are by convention all-uppercase.
+  return fetch(href, { method: method.toUpperCase(), body, headers });
 }
 
 function shallowClone<T>(obj: T): T {


### PR DESCRIPTION
Quick fix for method name compliance with the HTTP RFCs.

IMO, a slightly more appropriate fix would be to just use all-uppercase strings in the `HttpMethod` type, but that seems to require a slightly larger diff.