### PR TITLE
fix: typo in init.ts

### DIFF
--- a/init.ts
+++ b/init.ts
@@ -166,7 +166,7 @@ export default async function init(nameArg?: string, template?: string) {
   ]);
 
   if (await confirm("Initialize VS Code workspace configuration?")) {
-    const settigns = {
+    const settings = {
       "deno.enable": true,
       "deno.lint": true,
       "deno.config": "./deno.json",
@@ -174,7 +174,7 @@ export default async function init(nameArg?: string, template?: string) {
     await ensureDir(join(appDir, ".vscode"));
     await Deno.writeTextFile(
       join(appDir, ".vscode", "settings.json"),
-      JSON.stringify(settigns, undefined, 2),
+      JSON.stringify(settings, undefined, 2),
     );
   }
 


### PR DESCRIPTION
Howdy! My first contribution to Aleph.js here is quite minimal, just a typo fix.

- [x] `settigns` -> `settings` in `init.ts`

Thanks for the amazing project!